### PR TITLE
Remove inactive google groups

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,8 +123,6 @@ API Reference</h1>
 <li><a class="el" href="type_specification.html">LCM Type Specification Language</a></li>
 <li><a class="el" href="udp_multicast_protocol.html">LCM UDP Multicast Protocol Description</a></li>
 <li><a class="el" href="log_file_format.html">LCM Log File format</a></li>
-<li><a href="http://groups.google.com/group/lcm-users">User mailing list</a></li>
-<li><a href="http://groups.google.com/group/lcm-dev">Developer mailing list</a></li>
 </ul>
 <h2>Publications and application notes</h2>
 <ul>


### PR DESCRIPTION
Both mailing list links display the following message:

![image](https://user-images.githubusercontent.com/996657/70481321-312fbd80-1ab0-11ea-8750-5e57a91c7085.png)